### PR TITLE
feat: 알림 읽음, 새 알림 여부 확인 기능 구현

### DIFF
--- a/stayswap-api/src/main/java/com/stayswap/notification/controller/CheckNewNotificationController.java
+++ b/stayswap-api/src/main/java/com/stayswap/notification/controller/CheckNewNotificationController.java
@@ -1,0 +1,29 @@
+package com.stayswap.notification.controller;
+
+import com.stayswap.common.resolver.userinfo.UserInfo;
+import com.stayswap.common.resolver.userinfo.UserInfoDto;
+import com.stayswap.model.RestApiResponse;
+import com.stayswap.notification.model.dto.response.CheckNewNotificationResponse;
+import com.stayswap.notification.service.CheckNewNotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "알림 API", description = "알림 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications/new")
+public class CheckNewNotificationController {
+
+    private final CheckNewNotificationService checkNewNotificationService;
+
+    @Operation(summary = "새 알림 여부 확인", description = "사용자에게 읽지 않은 새 알림이 있는지 확인합니다.")
+    @GetMapping
+    public RestApiResponse<CheckNewNotificationResponse> checkNewNotification(@UserInfo UserInfoDto userInfo) {
+        boolean hasNew = checkNewNotificationService.checkNewNotification(userInfo.getUserId());
+        return RestApiResponse.success(new CheckNewNotificationResponse(hasNew));
+    }
+} 

--- a/stayswap-api/src/main/java/com/stayswap/notification/controller/NotificationReadController.java
+++ b/stayswap-api/src/main/java/com/stayswap/notification/controller/NotificationReadController.java
@@ -1,0 +1,31 @@
+package com.stayswap.notification.controller;
+
+import com.stayswap.common.resolver.userinfo.UserInfo;
+import com.stayswap.common.resolver.userinfo.UserInfoDto;
+import com.stayswap.model.RestApiResponse;
+import com.stayswap.notification.model.dto.response.SetLastReadAtResponse;
+import com.stayswap.notification.service.LastReadAtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+
+@Tag(name = "알림 API", description = "알림 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications/read")
+public class NotificationReadController {
+
+    private final LastReadAtService lastReadAtService;
+
+    @Operation(summary = "알림 읽음 처리", description = "현재 시간을 사용자의 마지막 알림 읽은 시간으로 Redis에 저장합니다.")
+    @PostMapping
+    public RestApiResponse<SetLastReadAtResponse> setLastReadAt(@UserInfo UserInfoDto userInfo) {
+        Instant lastReadAt = lastReadAtService.setLastReadAt(userInfo.getUserId());
+        return RestApiResponse.success(new SetLastReadAtResponse(lastReadAt));
+    }
+} 

--- a/stayswap-domain/src/main/java/com/stayswap/notification/model/dto/response/CheckNewNotificationResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/notification/model/dto/response/CheckNewNotificationResponse.java
@@ -1,0 +1,16 @@
+package com.stayswap.notification.model.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "새 알림 여부 확인 응답")
+public class CheckNewNotificationResponse {
+    
+    @Schema(description = "새 알림 존재 여부")
+    private boolean hasNew;
+} 

--- a/stayswap-domain/src/main/java/com/stayswap/notification/model/dto/response/SetLastReadAtResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/notification/model/dto/response/SetLastReadAtResponse.java
@@ -1,0 +1,18 @@
+package com.stayswap.notification.model.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "알림 읽은 시간 설정 응답")
+public class SetLastReadAtResponse {
+    
+    @Schema(description = "마지막 읽은 시간")
+    private Instant lastReadAt;
+} 

--- a/stayswap-domain/src/main/java/com/stayswap/notification/repository/NotificationMongoRepository.java
+++ b/stayswap-domain/src/main/java/com/stayswap/notification/repository/NotificationMongoRepository.java
@@ -10,9 +10,11 @@ import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface NotificationMongoRepository extends MongoRepository<Notification, String> {
     Slice<Notification> findAllByRecipientIdOrderByOccurredAtDesc(Long recipientId, Pageable page);
     Slice<Notification> findAllByRecipientIdAndOccurredAtLessThanOrderByOccurredAtDesc(Long recipientId, Instant occurredAt, Pageable pageable);
+    Optional<Notification> findFirstByRecipientIdOrderByLastUpdatedAtDesc(Long recipientId);
 }

--- a/stayswap-domain/src/main/java/com/stayswap/notification/repository/NotificationReadRepository.java
+++ b/stayswap-domain/src/main/java/com/stayswap/notification/repository/NotificationReadRepository.java
@@ -1,0 +1,50 @@
+package com.stayswap.notification.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class NotificationReadRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public NotificationReadRepository(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * 사용자의 알림 마지막 읽은 시간을 설정
+     * Redis에 90일 TTL로 저장
+     */
+    public Instant setLastReadAt(Long userId) {
+        long lastReadAt = Instant.now().toEpochMilli();
+        String key = getKey(userId);
+        redisTemplate.opsForValue().set(key, String.valueOf(lastReadAt));
+        redisTemplate.expire(key, 90, TimeUnit.DAYS); // 90일 TTL 설정
+        return Instant.ofEpochMilli(lastReadAt);
+    }
+
+    /**
+     * 사용자의 알림 마지막 읽은 시간 조회
+     */
+    public Instant getLastReadAt(Long userId) {
+        String key = getKey(userId);
+        String lastReadAtStr = redisTemplate.opsForValue().get(key);
+        if (lastReadAtStr == null) {
+            return null;
+        }
+
+        long lastReadAtLong = Long.parseLong(lastReadAtStr);
+        return Instant.ofEpochMilli(lastReadAtLong);
+    }
+
+    /**
+     * Redis 키 생성
+     */
+    private String getKey(Long userId) {
+        return "notification:" + userId + ":lastReadAt";
+    }
+} 

--- a/stayswap-domain/src/main/java/com/stayswap/notification/service/CheckNewNotificationService.java
+++ b/stayswap-domain/src/main/java/com/stayswap/notification/service/CheckNewNotificationService.java
@@ -1,0 +1,49 @@
+package com.stayswap.notification.service;
+
+import com.stayswap.notification.model.document.Notification;
+import com.stayswap.notification.repository.NotificationMongoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * 새 알림 여부 확인 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CheckNewNotificationService {
+
+    private final NotificationMongoRepository notificationMongoRepository;
+    private final LastReadAtService lastReadAtService;
+
+    /**
+     * 사용자의 새 알림 여부 확인
+     */
+    public boolean checkNewNotification(Long userId) {
+        Instant latestUpdatedAt = getLatestUpdatedAt(userId);
+        if (latestUpdatedAt == null) {
+            return false;
+        }
+
+        Instant lastReadAt = lastReadAtService.getLastReadAt(userId);
+        if (lastReadAt == null) { // 읽은 시간이 없으면 새 알림이 있는것
+            return true;
+        }
+
+        return latestUpdatedAt.isAfter(lastReadAt);
+    }
+
+    /**
+     * 사용자의 가장 최근 알림 업데이트 시간 조회
+     */
+    private Instant getLatestUpdatedAt(Long userId) {
+        Optional<Notification> notification = notificationMongoRepository.findFirstByRecipientIdOrderByLastUpdatedAtDesc(userId);
+        return notification.map(Notification::getLastUpdatedAt).orElse(null);
+    }
+} 

--- a/stayswap-domain/src/main/java/com/stayswap/notification/service/LastReadAtService.java
+++ b/stayswap-domain/src/main/java/com/stayswap/notification/service/LastReadAtService.java
@@ -1,0 +1,31 @@
+package com.stayswap.notification.service;
+
+import com.stayswap.notification.repository.NotificationReadRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+/**
+ * 알림 읽은 시간 관리 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class LastReadAtService {
+
+    private final NotificationReadRepository notificationReadRepository;
+
+    /**
+     * 사용자의 알림 마지막 읽은 시간을 현재 시간으로 설정
+     */
+    public Instant setLastReadAt(Long userId) {
+        return notificationReadRepository.setLastReadAt(userId);
+    }
+
+    /**
+     * 사용자의 알림 마지막 읽은 시간 조회
+     */
+    public Instant getLastReadAt(Long userId) {
+        return notificationReadRepository.getLastReadAt(userId);
+    }
+} 


### PR DESCRIPTION
## 💡 **개요**
- #57 
## 📑 **작업 사항**
- 알림 읽을시 redis에 현재시간을 마지막 읽음시간으로 update한다. TTL은 90일로 한다.
- 새 알림 여부 확인은 mongoDB에서 가장 최근 알림 업데이트 시간을 조회하고
redis에서 마지막 읽음시간을 조회해서 둘이 시간을 비교하여 새 알림 여부 확인을 한다.
- `latestUpdatedAt > lastReadAt` → 새 알림 존재