### PR TITLE
refact: 배치쿼리 적용하여 알림  조회

### DIFF
--- a/stayswap-common/src/main/java/com/stayswap/notification/dto/response/NotificationResponse.java
+++ b/stayswap-common/src/main/java/com/stayswap/notification/dto/response/NotificationResponse.java
@@ -17,6 +17,8 @@ public class NotificationResponse {
     private String id;                  // 알림 ID
     private Long recipientId;           // 수신자 ID
     private Long senderId;              // 발신자 ID
+    private String senderName;          // 발신자 이름
+    private String senderProfile;       // 발신자 프로필 이미지
     private Long referenceId;           // 참조 ID (예약, 교환 등)
     private String title;               // 알림 제목
     private String content;             // 알림 내용
@@ -25,11 +27,13 @@ public class NotificationResponse {
     private Instant occurredAt;         // 이벤트 발생 시간
     private Instant createdAt;          // 생성 시간
 
-    public static NotificationResponse from(Notification notification) {
+    public static NotificationResponse from(Notification notification, String senderName, String senderProfile) {
         return NotificationResponse.builder()
                 .id(notification.getId())
                 .recipientId(notification.getRecipientId())
                 .senderId(notification.getSenderId())
+                .senderName(senderName != null ? senderName : "알 수 없음")
+                .senderProfile(senderProfile)
                 .referenceId(notification.getReferenceId())
                 .title(notification.getTitle())
                 .content(notification.getContent())

--- a/stayswap-domain/src/main/java/com/stayswap/user/repository/UserRepository.java
+++ b/stayswap-domain/src/main/java/com/stayswap/user/repository/UserRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
@@ -22,5 +24,7 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 
     @Query("SELECT u.refreshToken FROM User u WHERE u.id = :userId")
     String findRefreshTokenById(@Param("userId") Long userId);
+
+    List<User> findByIdIn(Set<Long> userIds);
 
 }


### PR DESCRIPTION
## 💡 **개요**
- #76 
## 📑 **작업 사항**
- 알림 UI에 발신자 이름/프로필 표시를 위해 MongoDB 중복저장 vs 배치쿼리 중 배치쿼리 방식 선택
- NotificationResponse에 senderName, senderProfile 필드 추가하고 배치 조회로 N+1 문제 방지
- 데이터 정합성 유지하면서 쿼리 수 최적화 
