### PR TITLE
feat: 사용자 프로필 사진 업데이트 api

### DIFF
--- a/stayswap-api/src/main/java/com/stayswap/user/controller/UserController.java
+++ b/stayswap-api/src/main/java/com/stayswap/user/controller/UserController.java
@@ -11,8 +11,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -70,6 +74,19 @@ public class UserController {
 
         return RestApiResponse.success(
                 userService.updateIntroduction(request, userInfo.getUserId()));
+    }
+
+    @Operation(
+            summary = "사용자 프로필 이미지 수정 API",
+            description = "사용자 프로필 이미지를 수정합니다. 기존 이미지가 S3에 저장된 경우 자동으로 삭제됩니다."
+    )
+    @PostMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public RestApiResponse<UpdateProfileImageResponse> updateProfileImage(
+            @RequestParam("profileImage") MultipartFile profileImage,
+            @UserInfo UserInfoDto userInfo) throws IOException {
+
+        return RestApiResponse.success(
+                userService.updateProfileImage(profileImage, userInfo.getUserId()));
     }
 
     @Operation(

--- a/stayswap-common/src/main/java/com/stayswap/code/ErrorCode.java
+++ b/stayswap-common/src/main/java/com/stayswap/code/ErrorCode.java
@@ -51,7 +51,8 @@ public enum ErrorCode {
     NOT_FOUND_REFRESH_TOKEN(FORBIDDEN, false, "F003", "리프레시 토큰을 찾을 수 없습니다."),
     REFRESH_TOKEN_EXPIRED(FORBIDDEN, false, "F004", "리프레시 토큰이 만료되었습니다."),
     NOT_MY_NICKNAME(FORBIDDEN, false, "F005", "자신의 닉네임만 수정할 수 있습니다."),
-    NOT_MY_INTRODUCTION(FORBIDDEN, false, "F006", "자신의 소개만 수정할 수 있습니다.");
+    NOT_MY_INTRODUCTION(FORBIDDEN, false, "F006", "자신의 소개만 수정할 수 있습니다."),
+    NOT_MY_PROFILE(FORBIDDEN, false, "F007", "자신의 프로필만 수정할 수 있습니다.");
 
 
     private final HttpStatusCode statusCode;

--- a/stayswap-domain/src/main/java/com/stayswap/user/model/dto/response/UpdateProfileImageResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/user/model/dto/response/UpdateProfileImageResponse.java
@@ -1,0 +1,22 @@
+package com.stayswap.user.model.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateProfileImageResponse {
+
+    @Schema(description = "업데이트된 프로필 이미지 URL", example = "https://s3.amazonaws.com/bucket/image/profile_123.jpg")
+    private String profileImageUrl;
+
+    public static UpdateProfileImageResponse of(String profileImageUrl) {
+        return UpdateProfileImageResponse.builder()
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+} 

--- a/stayswap-domain/src/main/java/com/stayswap/user/service/device/UserDeviceService.java
+++ b/stayswap-domain/src/main/java/com/stayswap/user/service/device/UserDeviceService.java
@@ -1,0 +1,94 @@
+package com.stayswap.user.service.device;
+
+import com.stayswap.error.exception.NotFoundException;
+import com.stayswap.user.model.dto.request.DeviceRegistrationRequest;
+import com.stayswap.user.model.entity.User;
+import com.stayswap.user.model.entity.UserDevice;
+import com.stayswap.user.repository.UserDeviceRepository;
+import com.stayswap.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.stayswap.code.ErrorCode.NOT_EXISTS_USER;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserDeviceService {
+
+    private final UserRepository userRepository;
+    private final UserDeviceRepository userDeviceRepository;
+
+    /**
+     * 사용자 디바이스 등록
+     */
+    public void registerDevice(Long userId, DeviceRegistrationRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(NOT_EXISTS_USER));
+
+        // FCM 토큰이 이미 등록되어 있는지 확인
+        Optional<UserDevice> existingDevice = userDeviceRepository.findByFcmToken(request.getFcmToken());
+
+        if (existingDevice.isPresent()) {
+            UserDevice device = existingDevice.get();
+            // 다른 사용자의 디바이스였다면 현재 사용자로 변경
+            if (!device.getUser().getId().equals(userId)) {
+                // 기존 디바이스 비활성화
+                device.deactivate();
+                
+                // 새 디바이스로 등록
+                createNewDevice(user, request);
+            }
+            // 같은 사용자의 디바이스라면 정보 업데이트
+            else {
+                // FCM 토큰이 같으므로 디바이스 정보만 업데이트
+                device.updateFcmToken(request.getFcmToken());
+            }
+        } else {
+            // 새 디바이스 등록
+            createNewDevice(user, request);
+        }
+        log.info("사용자 디바이스 등록 완료: userId={}, deviceType={}", userId, request.getDeviceType());
+    }
+
+    /**
+     * 새 디바이스 생성 및 저장
+     */
+    private UserDevice createNewDevice(User user, DeviceRegistrationRequest request) {
+        UserDevice newDevice = UserDevice.builder()
+                .user(user)
+                .deviceType(request.getDeviceType())
+                .deviceModel(request.getDeviceModel())
+                .fcmToken(request.getFcmToken())
+                .deviceId(request.getDeviceId())
+                .build();
+        
+        return userDeviceRepository.save(newDevice);
+    }
+
+    /**
+     * 사용자의 모든 활성 디바이스 FCM 토큰 조회
+     */
+    @Transactional(readOnly = true)
+    public List<String> getActiveFcmTokensByUserId(Long userId) {
+        List<UserDevice> devices = userDeviceRepository.findActiveDevicesByUserId(userId);
+        return devices.stream()
+                .map(UserDevice::getFcmToken)
+                .toList();
+    }
+
+    /**
+     * FCM 토큰 비활성화
+     */
+    public void deactivateToken(String fcmToken) {
+        userDeviceRepository.findByFcmToken(fcmToken)
+                .ifPresent(UserDevice::deactivate);
+    }
+} 


### PR DESCRIPTION
## 💡 **개요**
- 사용자 프로필 사진 업데이트 api
## 📑 **작업 사항**
- 프로필 사진 변경시 S3에 저장하고 db에 url 교체
- 재업로드시 기존 s3이미지 바로 삭제 후 새 이미지 업로드
- service 로직 더러운것 추후 리팩토링
