### PR TITLE
fix:  숙소 상세 조회 시 Geocoding API 호출 최적화

### DIFF
--- a/stayswap-api/src/main/java/com/stayswap/common/config/GoogleMapsConfig.java
+++ b/stayswap-api/src/main/java/com/stayswap/common/config/GoogleMapsConfig.java
@@ -1,0 +1,17 @@
+package com.stayswap.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Configuration
+public class GoogleMapsConfig {
+
+    @Value("${google.maps.api.key}")
+    private String apiKey;
+    
+} 

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/request/CreateHouseRequest.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/request/CreateHouseRequest.java
@@ -49,6 +49,24 @@ public class CreateHouseRequest {
     @Schema(description = "지역구", example = "강남구")
     private String district;
 
+    @Schema(description = "위도", example = "37.5665")
+    private Double latitude;
+
+    @Schema(description = "경도", example = "126.9780")
+    private Double longitude;
+
+    @Schema(description = "지도 영역 북동쪽 위도", example = "37.5670")
+    private Double viewportNortheastLat;
+
+    @Schema(description = "지도 영역 북동쪽 경도", example = "126.9785")
+    private Double viewportNortheastLng;
+
+    @Schema(description = "지도 영역 남서쪽 위도", example = "37.5660")
+    private Double viewportSouthwestLat;
+
+    @Schema(description = "지도 영역 남서쪽 경도", example = "126.9775")
+    private Double viewportSouthwestLng;
+
     @Schema(description = "반려동물 허용 여부", example = "true")
     private Boolean petsAllowed;
     
@@ -147,6 +165,12 @@ public class CreateHouseRequest {
                 address,
                 city,
                 district,
+                latitude,
+                longitude,
+                viewportNortheastLat,
+                viewportNortheastLng,
+                viewportSouthwestLat,
+                viewportSouthwestLng,
                 petsAllowed,
                 user,
                 houseOption

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/request/UpdateHouseRequest.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/request/UpdateHouseRequest.java
@@ -50,6 +50,24 @@ public class UpdateHouseRequest {
     @Schema(description = "지역구", example = "강남구")
     private String district;
 
+    @Schema(description = "위도", example = "37.5665")
+    private Double latitude;
+
+    @Schema(description = "경도", example = "126.9780")
+    private Double longitude;
+
+    @Schema(description = "지도 영역 북동쪽 위도", example = "37.5670")
+    private Double viewportNortheastLat;
+
+    @Schema(description = "지도 영역 북동쪽 경도", example = "126.9785")
+    private Double viewportNortheastLng;
+
+    @Schema(description = "지도 영역 남서쪽 위도", example = "37.5660")
+    private Double viewportSouthwestLat;
+
+    @Schema(description = "지도 영역 남서쪽 경도", example = "126.9775")
+    private Double viewportSouthwestLng;
+
     @Schema(description = "반려동물 허용 여부", example = "true")
     private Boolean petsAllowed;
     
@@ -149,6 +167,12 @@ public class UpdateHouseRequest {
             address,
             city,
             district,
+            latitude,
+            longitude,
+            viewportNortheastLat,
+            viewportNortheastLng,
+            viewportSouthwestLat,
+            viewportSouthwestLng,
             petsAllowed,
             options != null ? options.toEntity() : null
         );

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/HouseDetailResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/HouseDetailResponse.java
@@ -63,6 +63,24 @@ public class HouseDetailResponse {
     @Schema(description = "편의시설 정보")
     private AmenityInfo amenityInfo;
 
+    @Schema(description = "위도", example = "37.5466")
+    private Double latitude;
+
+    @Schema(description = "경도", example = "127.21395")
+    private Double longitude;
+
+    @Schema(description = "지도 영역 북동쪽 위도", example = "37.5470")
+    private Double viewportNortheastLat;
+
+    @Schema(description = "지도 영역 북동쪽 경도", example = "127.2145")
+    private Double viewportNortheastLng;
+
+    @Schema(description = "지도 영역 남서쪽 위도", example = "37.5462")
+    private Double viewportSouthwestLat;
+
+    @Schema(description = "지도 영역 남서쪽 경도", example = "127.2134")
+    private Double viewportSouthwestLng;
+
     @Getter
     @Schema(description = "편의시설 정보")
     @NoArgsConstructor

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/entity/House.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/entity/House.java
@@ -52,6 +52,25 @@ public class House extends BaseTimeEntity {
 
     private String district;
 
+    @Column(columnDefinition = "DECIMAL(10,7)")
+    private Double latitude;
+
+    @Column(columnDefinition = "DECIMAL(10,7)")
+    private Double longitude;
+
+    // viewport 영역 정보 (빨간색 영역 표시용)
+    @Column(name = "viewport_northeast_lat", columnDefinition = "DECIMAL(10,7)")
+    private Double viewportNortheastLat;
+
+    @Column(name = "viewport_northeast_lng", columnDefinition = "DECIMAL(10,7)")
+    private Double viewportNortheastLng;
+
+    @Column(name = "viewport_southwest_lat", columnDefinition = "DECIMAL(10,7)")
+    private Double viewportSouthwestLat;
+
+    @Column(name = "viewport_southwest_lng", columnDefinition = "DECIMAL(10,7)")
+    private Double viewportSouthwestLng;
+
     @Column(name = "pets_allowed")
     private Boolean petsAllowed;
 
@@ -73,7 +92,7 @@ public class House extends BaseTimeEntity {
     @Builder.Default
     private List<HouseLike> houseLikes = new ArrayList<>();
 
-    public static House newHouse(String title, String description, String rule, HouseType type, Float size, Integer bedrooms, Integer bed, Integer bathrooms, Integer maxGuests, String address, String city, String district, Boolean petsAllowed, User user, HouseOption houseOption) {
+    public static House newHouse(String title, String description, String rule, HouseType type, Float size, Integer bedrooms, Integer bed, Integer bathrooms, Integer maxGuests, String address, String city, String district, Double latitude, Double longitude, Double viewportNortheastLat, Double viewportNortheastLng, Double viewportSouthwestLat, Double viewportSouthwestLng, Boolean petsAllowed, User user, HouseOption houseOption) {
         return House.builder()
                 .title(title)
                 .description(description)
@@ -87,6 +106,12 @@ public class House extends BaseTimeEntity {
                 .address(address)
                 .city(city)
                 .district(district)
+                .latitude(latitude)
+                .longitude(longitude)
+                .viewportNortheastLat(viewportNortheastLat)
+                .viewportNortheastLng(viewportNortheastLng)
+                .viewportSouthwestLat(viewportSouthwestLat)
+                .viewportSouthwestLng(viewportSouthwestLng)
                 .petsAllowed(petsAllowed)
                 .isActive(true)
                 .isDelete(false)
@@ -97,7 +122,7 @@ public class House extends BaseTimeEntity {
     
     public void update(String title, String description, String rule, HouseType type, Float size, Integer bedrooms, 
                       Integer bed, Integer bathrooms, Integer maxGuests, String address, String city, 
-                      String district, Boolean petsAllowed, HouseOption houseOption) {
+                      String district, Double latitude, Double longitude, Double viewportNortheastLat, Double viewportNortheastLng, Double viewportSouthwestLat, Double viewportSouthwestLng, Boolean petsAllowed, HouseOption houseOption) {
         this.title = title;
         this.description = description;
         this.rule = rule;
@@ -110,6 +135,12 @@ public class House extends BaseTimeEntity {
         this.address = address;
         this.city = city;
         this.district = district;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.viewportNortheastLat = viewportNortheastLat;
+        this.viewportNortheastLng = viewportNortheastLng;
+        this.viewportSouthwestLat = viewportSouthwestLat;
+        this.viewportSouthwestLng = viewportSouthwestLng;
         this.petsAllowed = petsAllowed;
         
         if (houseOption != null) {

--- a/stayswap-domain/src/main/java/com/stayswap/house/repository/HouseRepositoryImpl.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/repository/HouseRepositoryImpl.java
@@ -127,7 +127,13 @@ public class HouseRepositoryImpl implements HouseRepositoryCustom {
                                 houseOption.hasElevator,
                                 houseOption.otherAmenities,
                                 houseOption.otherFeatures
-                        )
+                        ),
+                        house.latitude,
+                        house.longitude,
+                        house.viewportNortheastLat,
+                        house.viewportNortheastLng,
+                        house.viewportSouthwestLat,
+                        house.viewportSouthwestLng
                 ))
                 .from(house)
                 .join(house.user, user)

--- a/stayswap-domain/src/main/java/com/stayswap/review/model/dto/response/ReceivedReviewResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/review/model/dto/response/ReceivedReviewResponse.java
@@ -9,13 +9,12 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class ReceivedReviewResponse {
     private Long reviewId;
     private Long reviewerId; // 리뷰 작성자 ID
-    private String reviewerName; // 리뷰 작성자 이름
     private String reviewerNickname; // 리뷰 작성자 닉네임
     private String reviewerProfile; // 리뷰 작성자 프로필 사진
     private Integer rating; // 평점
@@ -28,7 +27,6 @@ public class ReceivedReviewResponse {
         return ReceivedReviewResponse.builder()
                 .reviewId(review.getId())
                 .reviewerId(review.getUser().getId())
-                .reviewerName(review.getUser().getUserName())
                 .reviewerNickname(review.getUser().getNickname())
                 .reviewerProfile(review.getUser().getProfile())
                 .rating(review.getRating())

--- a/stayswap-domain/src/main/java/com/stayswap/review/repository/ReviewRepositoryCustomImpl.java
+++ b/stayswap-domain/src/main/java/com/stayswap/review/repository/ReviewRepositoryCustomImpl.java
@@ -65,14 +65,13 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
                         ReceivedReviewResponse.class,
                         review.id,
                         review.user.id,
-                        review.user.nickname.as("userName"),
-                        review.user.profile.as("userProfile"),
-                        review.targetHouse.id,
-                        review.targetHouse.title.as("houseTitle"),
-                        houseImage.imageUrl.as("houseImage"),
+                        review.user.nickname.as("reviewerNickname"),
+                        review.user.profile.as("reviewerProfile"),
                         review.rating,
                         review.comment,
-                        review.regTime
+                        review.regTime.as("createdDate"),
+                        review.targetHouse.title.as("houseTitle"),
+                        review.targetHouse.id.stringValue().as("houseId")
                 ))
                 .from(review)
                 .innerJoin(review.targetHouse, house)


### PR DESCRIPTION
## 💡 **개요**
- #83 
## 📑 **작업 사항**
- [as-is] 숙소 상세 조회 -> Geocoding api 호출 -> 좌표 -> 지도 렌더링
- [to-be] 숙소 등록시 viewport에 쓸 좌표 db에 등록 -> db에서 좌표 조회 -> 바로 지도 렌더링


