### PR TITLE
feat: 현재 등록된 숙소 기반으로 국가 목록 조회 api

### DIFF
--- a/stayswap-api/src/main/java/com/stayswap/house/controller/HouseController.java
+++ b/stayswap-api/src/main/java/com/stayswap/house/controller/HouseController.java
@@ -83,6 +83,16 @@ public class HouseController {
     }
 
     @Operation(
+            summary = "등록된 숙소 국가 목록 조회 API",
+            description = "현재 등록된 숙소들의 국가 목록을 중복 제거하여 조회합니다. " +
+                    "위치 필터링을 위한 select box 옵션으로 사용할 수 있습니다."
+    )
+    @GetMapping("/countries")
+    public RestApiResponse<List<CountryResponse>> getDistinctCountries() {
+        return RestApiResponse.success(houseService.getDistinctCountries());
+    }
+
+    @Operation(
             summary = "숙소 상세 조회 API",
             description = "숙소 상세 정보를 조회합니다. " +
                     "숙소의 기본 정보, 이미지, 편의시설 정보, 호스트 ID 등을 포함합니다."

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/CountryResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/CountryResponse.java
@@ -1,0 +1,17 @@
+package com.stayswap.house.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CountryResponse {
+    private String countryKo;
+    private String countryEn;
+
+    public static CountryResponse of(String countryKo, String countryEn) {
+        return new CountryResponse(countryKo, countryEn);
+    }
+} 

--- a/stayswap-domain/src/main/java/com/stayswap/house/repository/HouseRepositoryCustom.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/repository/HouseRepositoryCustom.java
@@ -22,4 +22,6 @@ public interface HouseRepositoryCustom {
     List<HouseImageResponse> getHouseImages(Long houseId);
     
     Slice<MyHouseResponse> getMyHouses(Long userId, Pageable pageable);
+    
+    List<CountryResponse> getDistinctCountries();
 } 

--- a/stayswap-domain/src/main/java/com/stayswap/house/repository/HouseRepositoryImpl.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/repository/HouseRepositoryImpl.java
@@ -153,6 +153,30 @@ public class HouseRepositoryImpl implements HouseRepositoryCustom {
     }
 
     @Override
+    public List<CountryResponse> getDistinctCountries() {
+        return queryFactory
+                .select(Projections.constructor(
+                        CountryResponse.class,
+                        house.countryKo,
+                        house.countryEn
+                ))
+                .from(house)
+                .where(
+                    house.countryKo.isNotNull()
+                    .and(house.countryKo.ne(""))
+                    .or(
+                        house.countryEn.isNotNull()
+                        .and(house.countryEn.ne(""))
+                    )
+                    .and(house.isActive.isTrue())
+                    .and(house.isDelete.isFalse())
+                )
+                .distinct()
+                .orderBy(house.countryKo.asc())
+                .fetch();
+    }
+
+    @Override
     public HostDetailResponse getHostDetailById(Long hostId) {
         // 리뷰
         NumberExpression<Long> reviewCount = Expressions.numberTemplate(Long.class,

--- a/stayswap-domain/src/main/java/com/stayswap/house/service/HouseService.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/service/HouseService.java
@@ -90,6 +90,12 @@ public class HouseService {
         return houseRepository.getHouseList(request, pageable);
     }
 
+    // 등록된 숙소들의 국가 목록 조회
+    @Transactional(readOnly = true)
+    public List<CountryResponse> getDistinctCountries() {
+        return houseRepository.getDistinctCountries();
+    }
+
     // 숙소 상세 정보 조회
     @Transactional(readOnly = true)
     public HouseDetailResponse getHouseDetail(Long houseId) {


### PR DESCRIPTION
## 💡 **개요**
- 숙소 리스트 조회에서 위치 필터링으로(select box 옵션) 활용하기 위한 api
## 📑 **작업 사항**
- 서비스 초기 단계에서는 places api를 사용하기보다는 사용자들이 등록한 숙소의 국가 기반으로 조회를한다.
- 한국어, 영어 국가명 중 하나라도 값이 있으면 조회
