### PR TITLE
feat: 다국어를 위해 숙소등록시 영어 주소도 받기

### DIFF
--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/request/CreateHouseRequest.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/request/CreateHouseRequest.java
@@ -40,14 +40,29 @@ public class CreateHouseRequest {
     @Schema(description = "최대 수용 인원", example = "4")
     private Integer maxGuests;
 
-    @Schema(description = "상세 주소", example = "서울특별시 강남구 테헤란로 123, 456동 789호")
-    private String address;
+    @Schema(description = "한국어 상세 주소", example = "서울특별시 강남구 테헤란로 123, 456동 789호")
+    private String addressKo;
 
-    @Schema(description = "도시명", example = "서울")
-    private String city;
+    @Schema(description = "한국어 도시명", example = "서울")
+    private String cityKo;
 
-    @Schema(description = "지역구", example = "강남구")
-    private String district;
+    @Schema(description = "한국어 지역구", example = "강남구")
+    private String districtKo;
+
+    @Schema(description = "한국어 국가명", example = "대한민국")
+    private String countryKo;
+
+    @Schema(description = "영어 상세 주소", example = "123 Teheran-ro, Gangnam-gu, Seoul, South Korea")
+    private String addressEn;
+
+    @Schema(description = "영어 도시명", example = "Seoul")
+    private String cityEn;
+
+    @Schema(description = "영어 지역구", example = "Gangnam-gu")
+    private String districtEn;
+
+    @Schema(description = "영어 국가명", example = "South Korea")
+    private String countryEn;
 
     @Schema(description = "위도", example = "37.5665")
     private Double latitude;
@@ -162,9 +177,14 @@ public class CreateHouseRequest {
                 bed,
                 bathrooms,
                 maxGuests,
-                address,
-                city,
-                district,
+                addressKo,
+                cityKo,
+                districtKo,
+                countryKo,
+                addressEn,
+                cityEn,
+                districtEn,
+                countryEn,
                 latitude,
                 longitude,
                 viewportNortheastLat,

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/request/HouseSearchRequest.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/request/HouseSearchRequest.java
@@ -22,6 +22,9 @@ public class HouseSearchRequest {
     @Schema(description = "도시", example = "서울")
     private String city;
 
+    @Schema(description = "국가", example = "대한민국")
+    private String country;
+
     @Schema(description = "숙소 유형", example = "APT")
     private HouseType houseType;
 

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/request/UpdateHouseRequest.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/request/UpdateHouseRequest.java
@@ -41,14 +41,29 @@ public class UpdateHouseRequest {
     @Schema(description = "최대 수용 인원", example = "4")
     private Integer maxGuests;
 
-    @Schema(description = "상세 주소", example = "서울특별시 강남구 테헤란로 123, 456동 789호")
-    private String address;
+    @Schema(description = "한국어 상세 주소", example = "서울특별시 강남구 테헤란로 123, 456동 789호")
+    private String addressKo;
 
-    @Schema(description = "도시명", example = "서울")
-    private String city;
+    @Schema(description = "한국어 도시명", example = "서울")
+    private String cityKo;
 
-    @Schema(description = "지역구", example = "강남구")
-    private String district;
+    @Schema(description = "한국어 지역구", example = "강남구")
+    private String districtKo;
+
+    @Schema(description = "한국어 국가명", example = "대한민국")
+    private String countryKo;
+
+    @Schema(description = "영어 상세 주소", example = "123 Teheran-ro, Gangnam-gu, Seoul, South Korea")
+    private String addressEn;
+
+    @Schema(description = "영어 도시명", example = "Seoul")
+    private String cityEn;
+
+    @Schema(description = "영어 지역구", example = "Gangnam-gu")
+    private String districtEn;
+
+    @Schema(description = "영어 국가명", example = "South Korea")
+    private String countryEn;
 
     @Schema(description = "위도", example = "37.5665")
     private Double latitude;
@@ -164,9 +179,14 @@ public class UpdateHouseRequest {
             bed,
             bathrooms,
             maxGuests,
-            address,
-            city,
-            district,
+            addressKo,
+            cityKo,
+            districtKo,
+            countryKo,
+            addressEn,
+            cityEn,
+            districtEn,
+            countryEn,
             latitude,
             longitude,
             viewportNortheastLat,

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/HouseDetailResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/HouseDetailResponse.java
@@ -2,32 +2,30 @@ package com.stayswap.house.model.dto.response;
 
 import com.stayswap.house.constant.HouseType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
-@Schema(description = "숙소 상세 조회 DTO")
-@NoArgsConstructor
+@Builder
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class HouseDetailResponse {
 
-    @Schema(description = "숙소(집) Id", example = "1")
+    @Schema(description = "숙소 ID", example = "1")
     private Long houseId;
 
-    @Schema(description = "숙소 제목", example = "서울 강남구의 아늑한 아파트")
+    @Schema(description = "숙소 제목", example = "서울 강남 아늑한 아파트")
     private String title;
 
-    @Schema(description = "숙소 설명", example = "강남역에서 도보 5분 거리에 위치한 모던한 아파트입니다...")
+    @Schema(description = "숙소 설명", example = "강남역 5분 거리에 위치한 깨끗하고 아늑한 2베드룸 아파트입니다. 편의시설이 잘 갖추어져 있으며 주변에 맛집이 많습니다.")
     private String description;
 
-    @Schema(description = "숙소 규칙", example = "흡연 금지, 파티 금지...")
+    @Schema(description = "숙소 이용 규칙", example = "뛰어다니지 마세요!")
     private String rule;
 
-    @Schema(description = "숙소 유형", example = "APARTMENT")
+    @Schema(description = "숙소 유형", example = "APT")
     private HouseType houseType;
 
-    @Schema(description = "크기(m²)", example = "80.5")
+    @Schema(description = "숙소 크기(평방미터)", example = "85.5")
     private Float size;
 
     @Schema(description = "침실 수", example = "2")
@@ -39,99 +37,86 @@ public class HouseDetailResponse {
     @Schema(description = "욕실 수", example = "1")
     private Integer bathrooms;
 
-    @Schema(description = "최대 숙박 인원", example = "4")
+    @Schema(description = "최대 수용 인원", example = "4")
     private Integer maxGuests;
 
-    @Schema(description = "도시", example = "서울시")
-    private String city;
+    @Schema(description = "한국어 도시명", example = "서울")
+    private String cityKo;
 
-    @Schema(description = "지역구", example = "강남구")
-    private String district;
+    @Schema(description = "한국어 지역구", example = "강남구")
+    private String districtKo;
+
+    @Schema(description = "한국어 국가명", example = "대한민국")
+    private String countryKo;
+
+    @Schema(description = "한국어 상세 주소", example = "서울특별시 강남구 테헤란로 123, 456동 789호")
+    private String addressKo;
+
+    @Schema(description = "영어 도시명", example = "Seoul")
+    private String cityEn;
+
+    @Schema(description = "영어 지역구", example = "Gangnam-gu")
+    private String districtEn;
+
+    @Schema(description = "영어 국가명", example = "South Korea")
+    private String countryEn;
+
+    @Schema(description = "영어 상세 주소", example = "123 Teheran-ro, Gangnam-gu, Seoul, South Korea")
+    private String addressEn;
 
     @Schema(description = "반려동물 허용 여부", example = "true")
     private Boolean petsAllowed;
 
-    @Schema(description = "평점", example = "4.9")
+    @Schema(description = "평균 평점", example = "4.5")
     private Double avgRating;
 
-    @Schema(description = "리뷰 수", example = "28")
+    @Schema(description = "리뷰 수", example = "10")
     private Long reviewCount;
 
     @Schema(description = "호스트 ID", example = "1")
     private Long hostId;
 
     @Schema(description = "편의시설 정보")
-    private AmenityInfo amenityInfo;
+    private AmenityInfo amenities;
 
-    @Schema(description = "위도", example = "37.5466")
+    @Schema(description = "위도", example = "37.5665")
     private Double latitude;
 
-    @Schema(description = "경도", example = "127.21395")
+    @Schema(description = "경도", example = "126.9780")
     private Double longitude;
 
-    @Schema(description = "지도 영역 북동쪽 위도", example = "37.5470")
+    @Schema(description = "지도 영역 북동쪽 위도", example = "37.5670")
     private Double viewportNortheastLat;
 
-    @Schema(description = "지도 영역 북동쪽 경도", example = "127.2145")
+    @Schema(description = "지도 영역 북동쪽 경도", example = "126.9785")
     private Double viewportNortheastLng;
 
-    @Schema(description = "지도 영역 남서쪽 위도", example = "37.5462")
+    @Schema(description = "지도 영역 남서쪽 위도", example = "37.5660")
     private Double viewportSouthwestLat;
 
-    @Schema(description = "지도 영역 남서쪽 경도", example = "127.2134")
+    @Schema(description = "지도 영역 남서쪽 경도", example = "126.9775")
     private Double viewportSouthwestLng;
 
     @Getter
-    @Schema(description = "편의시설 정보")
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class AmenityInfo {
-        @Schema(description = "무선 인터넷 제공 여부", example = "true")
-        private boolean hasFreeWifi;
-
-        @Schema(description = "에어컨 제공 여부", example = "true")
-        private boolean hasAirConditioner;
-
-        @Schema(description = "TV 제공 여부", example = "true")
-        private boolean hasTV;
-
-        @Schema(description = "세탁기 제공 여부", example = "true")
-        private boolean hasWashingMachine;
-
-        @Schema(description = "주방 제공 여부", example = "true")
-        private boolean hasKitchen;
-
-        @Schema(description = "건조기 제공 여부", example = "true")
-        private boolean hasDryer;
-
-        @Schema(description = "다리미 제공 여부", example = "true")
-        private boolean hasIron;
-
-        @Schema(description = "냉장고 제공 여부", example = "true")
-        private boolean hasRefrigerator;
-
-        @Schema(description = "전자레인지 제공 여부", example = "true")
-        private boolean hasMicrowave;
-
-        @Schema(description = "무료 주차 제공 여부", example = "true")
-        private boolean hasFreeParking;
-
-        @Schema(description = "발코니/테라스 제공 여부", example = "true")
-        private boolean hasBalconyTerrace;
-
-        @Schema(description = "반려동물 허용 여부", example = "true")
-        private boolean hasPetsAllowed;
-
-        @Schema(description = "흡연 허용 여부", example = "false")
-        private boolean hasSmokingAllowed;
-
-        @Schema(description = "엘리베이터 제공 여부", example = "true")
-        private boolean hasElevator;
-
-        @Schema(description = "기타 편의시설", example = "수영장, 헬스장")
+        private Boolean hasFreeWifi;
+        private Boolean hasAirConditioner;
+        private Boolean hasTV;
+        private Boolean hasWashingMachine;
+        private Boolean hasKitchen;
+        private Boolean hasDryer;
+        private Boolean hasIron;
+        private Boolean hasRefrigerator;
+        private Boolean hasMicrowave;
+        private Boolean hasFreeParking;
+        private Boolean hasBalconyTerrace;
+        private Boolean hasPetsAllowed;
+        private Boolean hasSmokingAllowed;
+        private Boolean hasElevator;
         private String otherAmenities;
-
-        @Schema(description = "기타 특징", example = "옥상 정원")
         private String otherFeatures;
     }
 }

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/HouseListResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/HouseListResponse.java
@@ -2,30 +2,46 @@ package com.stayswap.house.model.dto.response;
 
 import com.stayswap.house.constant.HouseType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
-@Schema(description = "숙소 목록 조회 DTO")
-@NoArgsConstructor
+@Builder
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class HouseListResponse {
 
-    @Schema(description = "숙소(집) Id", example = "1")
+    @Schema(description = "숙소 ID", example = "1")
     private Long houseId;
 
-    @Schema(description = "숙소 제목", example = "서울 강남구의 아늑한 아파트")
+    @Schema(description = "숙소 제목", example = "서울 강남 아늑한 아파트")
     private String title;
 
-    @Schema(description = "숙소 유형", example = "APARTMENT")
+    @Schema(description = "숙소 유형", example = "APT")
     private HouseType houseType;
 
-    @Schema(description = "도시", example = "서울시")
-    private String city;
+    @Schema(description = "한국어 도시명", example = "서울")
+    private String cityKo;
 
-    @Schema(description = "지역구", example = "강남구")
-    private String district;
+    @Schema(description = "한국어 지역구", example = "강남구")
+    private String districtKo;
+
+    @Schema(description = "한국어 국가명", example = "대한민국")
+    private String countryKo;
+
+    @Schema(description = "한국어 상세 주소", example = "서울특별시 강남구 테헤란로 123, 456동 789호")
+    private String addressKo;
+
+    @Schema(description = "영어 도시명", example = "Seoul")
+    private String cityEn;
+
+    @Schema(description = "영어 지역구", example = "Gangnam-gu")
+    private String districtEn;
+
+    @Schema(description = "영어 국가명", example = "South Korea")
+    private String countryEn;
+
+    @Schema(description = "영어 상세 주소", example = "123 Teheran-ro, Gangnam-gu, Seoul, South Korea")
+    private String addressEn;
 
     @Schema(description = "침실 수", example = "2")
     private Integer bedrooms;
@@ -33,15 +49,16 @@ public class HouseListResponse {
     @Schema(description = "침대 수", example = "3")
     private Integer bed;
 
-    @Schema(description = "최대 숙박 인원", example = "4")
+    @Schema(description = "최대 수용 인원", example = "4")
     private Integer maxGuests;
 
     @Schema(description = "대표 이미지 URL", example = "https://example.com/image.jpg")
     private String mainImageUrl;
 
-    @Schema(description = "평점", example = "4.5")
+    @Schema(description = "평균 평점", example = "4.5")
     private Double avgRating;
 
-    @Schema(description = "리뷰 수", example = "100")
+    @Schema(description = "리뷰 수", example = "10")
     private Long reviewCount;
+
 }

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/PopularHouseResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/PopularHouseResponse.java
@@ -2,6 +2,7 @@ package com.stayswap.house.model.dto.response;
 
 import com.stayswap.house.constant.HouseType;
 import com.stayswap.house.model.entity.House;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,8 +17,21 @@ public class PopularHouseResponse {
     private Long houseId;
     private String title;
     private HouseType houseType;
-    private String city;
-    private String district;
+
+    // 다국어 지원 필드들
+    private String addressKo;
+    @Schema(description = "한국어 도시명", example = "서울")
+    private String cityKo;
+    private String districtKo;
+    private String addressEn;
+    @Schema(description = "영어 도시명", example = "Seoul")
+    private String cityEn;
+    private String districtEn;
+    @Schema(description = "한국어 국가명", example = "대한민국")
+    private String countryKo;
+    @Schema(description = "영어 국가명", example = "South Korea")
+    private String countryEn;
+    
     private Integer bedrooms;
     private Integer bed;
     private Integer maxGuests;
@@ -30,8 +44,14 @@ public class PopularHouseResponse {
                 .houseId(house.getId())
                 .title(house.getTitle())
                 .houseType(house.getHouseType())
-                .city(house.getCity())
-                .district(house.getDistrict())
+                .addressKo(house.getAddressKo())
+                .cityKo(house.getCityKo())
+                .countryKo(house.getCountryKo())
+                .districtKo(house.getDistrictKo())
+                .addressEn(house.getAddressEn())
+                .cityEn(house.getCityEn())
+                .countryEn(house.getCountryEn())
+                .districtEn(house.getDistrictEn())
                 .bedrooms(house.getBedrooms())
                 .bed(house.getBed())
                 .maxGuests(house.getMaxGuests())

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/RecentHouseResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/RecentHouseResponse.java
@@ -2,6 +2,7 @@ package com.stayswap.house.model.dto.response;
 
 import com.stayswap.house.constant.HouseType;
 import com.stayswap.house.model.entity.House;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,8 +17,21 @@ import java.time.LocalDateTime;
 public class RecentHouseResponse {
     private Long id;
     private String title;
-    private String city;
-    private String district;
+
+    // 다국어 지원 필드들
+    private String addressKo;
+    @Schema(description = "한국어 도시명", example = "서울")
+    private String cityKo;
+    private String districtKo;
+    private String addressEn;
+    @Schema(description = "영어 도시명", example = "Seoul")
+    private String cityEn;
+    private String districtEn;
+    @Schema(description = "한국어 국가명", example = "대한민국")
+    private String countryKo;
+    @Schema(description = "영어 국가명", example = "South Korea")
+    private String countryEn;
+    
     private HouseType houseType;
     private Integer bedrooms;
     private Integer maxGuests;
@@ -28,8 +42,14 @@ public class RecentHouseResponse {
         return RecentHouseResponse.builder()
                 .id(house.getId())
                 .title(house.getTitle())
-                .city(house.getCity())
-                .district(house.getDistrict())
+                .addressKo(house.getAddressKo())
+                .cityKo(house.getCityKo())
+                .countryKo(house.getCountryKo())
+                .districtKo(house.getDistrictKo())
+                .addressEn(house.getAddressEn())
+                .cityEn(house.getCityEn())
+                .countryEn(house.getCountryEn())
+                .districtEn(house.getDistrictEn())
                 .houseType(house.getHouseType())
                 .bedrooms(house.getBedrooms())
                 .maxGuests(house.getMaxGuests())

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/entity/House.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/entity/House.java
@@ -46,11 +46,30 @@ public class House extends BaseTimeEntity {
 
     private Integer maxGuests;
 
-    private String address;
+    // 다국어 지원 필드들
+    @Column(name = "address_ko")
+    private String addressKo;
 
-    private String city;
+    @Column(name = "city_ko")
+    private String cityKo;
 
-    private String district;
+    @Column(name = "district_ko")
+    private String districtKo;
+
+    @Column(name = "country_ko")
+    private String countryKo;
+
+    @Column(name = "address_en")
+    private String addressEn;
+
+    @Column(name = "city_en")
+    private String cityEn;
+
+    @Column(name = "district_en")
+    private String districtEn;
+
+    @Column(name = "country_en")
+    private String countryEn;
 
     @Column(columnDefinition = "DECIMAL(10,7)")
     private Double latitude;
@@ -58,41 +77,39 @@ public class House extends BaseTimeEntity {
     @Column(columnDefinition = "DECIMAL(10,7)")
     private Double longitude;
 
-    // viewport 영역 정보 (빨간색 영역 표시용)
-    @Column(name = "viewport_northeast_lat", columnDefinition = "DECIMAL(10,7)")
+    @Column(columnDefinition = "DECIMAL(10,7)")
     private Double viewportNortheastLat;
 
-    @Column(name = "viewport_northeast_lng", columnDefinition = "DECIMAL(10,7)")
+    @Column(columnDefinition = "DECIMAL(10,7)")
     private Double viewportNortheastLng;
 
-    @Column(name = "viewport_southwest_lat", columnDefinition = "DECIMAL(10,7)")
+    @Column(columnDefinition = "DECIMAL(10,7)")
     private Double viewportSouthwestLat;
 
-    @Column(name = "viewport_southwest_lng", columnDefinition = "DECIMAL(10,7)")
+    @Column(columnDefinition = "DECIMAL(10,7)")
     private Double viewportSouthwestLng;
 
-    @Column(name = "pets_allowed")
     private Boolean petsAllowed;
 
-    @Column(name = "is_active")
     private Boolean isActive;
 
-    @Column(name = "is_delete")
     private Boolean isDelete;
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToOne(fetch = LAZY, cascade = ALL)
+    @OneToOne(cascade = ALL, orphanRemoval = true)
     @JoinColumn(name = "house_option_id")
     private HouseOption houseOption;
     
-    @OneToMany(mappedBy = "house", cascade = CascadeType.ALL)
-    @Builder.Default
+    @OneToMany(mappedBy = "house", cascade = ALL, orphanRemoval = true)
+    private List<HouseImage> houseImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "house", cascade = ALL, orphanRemoval = true)
     private List<HouseLike> houseLikes = new ArrayList<>();
 
-    public static House newHouse(String title, String description, String rule, HouseType type, Float size, Integer bedrooms, Integer bed, Integer bathrooms, Integer maxGuests, String address, String city, String district, Double latitude, Double longitude, Double viewportNortheastLat, Double viewportNortheastLng, Double viewportSouthwestLat, Double viewportSouthwestLng, Boolean petsAllowed, User user, HouseOption houseOption) {
+    public static House newHouse(String title, String description, String rule, HouseType type, Float size, Integer bedrooms, Integer bed, Integer bathrooms, Integer maxGuests, String addressKo, String cityKo, String districtKo, String countryKo, String addressEn, String cityEn, String districtEn, String countryEn, Double latitude, Double longitude, Double viewportNortheastLat, Double viewportNortheastLng, Double viewportSouthwestLat, Double viewportSouthwestLng, Boolean petsAllowed, User user, HouseOption houseOption) {
         return House.builder()
                 .title(title)
                 .description(description)
@@ -103,9 +120,14 @@ public class House extends BaseTimeEntity {
                 .bed(bed)
                 .bathrooms(bathrooms)
                 .maxGuests(maxGuests)
-                .address(address)
-                .city(city)
-                .district(district)
+                .addressKo(addressKo)
+                .cityKo(cityKo)
+                .districtKo(districtKo)
+                .countryKo(countryKo)
+                .addressEn(addressEn)
+                .cityEn(cityEn)
+                .districtEn(districtEn)
+                .countryEn(countryEn)
                 .latitude(latitude)
                 .longitude(longitude)
                 .viewportNortheastLat(viewportNortheastLat)
@@ -121,8 +143,10 @@ public class House extends BaseTimeEntity {
     }
     
     public void update(String title, String description, String rule, HouseType type, Float size, Integer bedrooms, 
-                      Integer bed, Integer bathrooms, Integer maxGuests, String address, String city, 
-                      String district, Double latitude, Double longitude, Double viewportNortheastLat, Double viewportNortheastLng, Double viewportSouthwestLat, Double viewportSouthwestLng, Boolean petsAllowed, HouseOption houseOption) {
+                      Integer bed, Integer bathrooms, Integer maxGuests, String addressKo, String cityKo, String districtKo, String countryKo,
+                      String addressEn, String cityEn, String districtEn, String countryEn, Double latitude, Double longitude, 
+                      Double viewportNortheastLat, Double viewportNortheastLng, Double viewportSouthwestLat, 
+                      Double viewportSouthwestLng, Boolean petsAllowed, HouseOption houseOption) {
         this.title = title;
         this.description = description;
         this.rule = rule;
@@ -132,9 +156,14 @@ public class House extends BaseTimeEntity {
         this.bed = bed;
         this.bathrooms = bathrooms;
         this.maxGuests = maxGuests;
-        this.address = address;
-        this.city = city;
-        this.district = district;
+        this.addressKo = addressKo;
+        this.cityKo = cityKo;
+        this.districtKo = districtKo;
+        this.countryKo = countryKo;
+        this.addressEn = addressEn;
+        this.cityEn = cityEn;
+        this.districtEn = districtEn;
+        this.countryEn = countryEn;
         this.latitude = latitude;
         this.longitude = longitude;
         this.viewportNortheastLat = viewportNortheastLat;

--- a/stayswap-domain/src/main/java/com/stayswap/house/repository/HouseRepositoryImpl.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/repository/HouseRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.stayswap.house.model.dto.request.HouseSearchRequest;
 import com.stayswap.house.model.dto.response.*;
@@ -44,8 +45,14 @@ public class HouseRepositoryImpl implements HouseRepositoryCustom {
                         house.id,
                         house.title,
                         house.houseType,
-                        house.city,
-                        house.district,
+                        house.cityKo,
+                        house.districtKo,
+                        house.countryKo,
+                        house.addressKo,
+                        house.cityEn,
+                        house.districtEn,
+                        house.countryEn,
+                        house.addressEn,
                         house.bedrooms,
                         house.bed,
                         house.maxGuests,
@@ -64,6 +71,7 @@ public class HouseRepositoryImpl implements HouseRepositoryCustom {
                 .where(
                         wholeKeyword(request.getKeyword()),
                         cityEq(request.getCity()),
+                        countryEq(request.getCountry()),
                         houseTypeEq(request.getHouseType()),
                         amenitiesContains(request.getAmenities()),
                         isActive(),
@@ -95,20 +103,23 @@ public class HouseRepositoryImpl implements HouseRepositoryCustom {
                         house.bed,
                         house.bathrooms,
                         house.maxGuests,
-                        house.city,
-                        house.district,
+                        house.cityKo,
+                        house.districtKo,
+                        house.countryKo,
+                        house.addressKo,
+                        house.cityEn,
+                        house.districtEn,
+                        house.countryEn,
+                        house.addressEn,
                         house.petsAllowed,
-                        // 평점
                         queryFactory.select(review.rating.avg().coalesce(0.0))
                                 .from(review)
                                 .where(review.targetHouse.id.eq(house.id))
                                 .where(review.rating.isNotNull()),
-                        // 리뷰 수
                         queryFactory.select(review.count().coalesce(0L))
                                 .from(review)
                                 .where(review.targetHouse.id.eq(house.id)),
                         house.user.id,
-                        // 편의시설 - 순서 수정
                         Projections.constructor(
                                 HouseDetailResponse.AmenityInfo.class,
                                 houseOption.hasFreeWifi,
@@ -272,14 +283,27 @@ public class HouseRepositoryImpl implements HouseRepositoryCustom {
     private BooleanExpression wholeKeyword(String keyword) {
         return hasText(keyword) ? house.title.containsIgnoreCase(keyword)
                 .or(house.description.containsIgnoreCase(keyword))
-                .or(house.address.containsIgnoreCase(keyword))
-                .or(house.city.containsIgnoreCase(keyword))
-                .or(house.district.containsIgnoreCase(keyword))
+                .or(house.addressKo.containsIgnoreCase(keyword))
+                .or(house.cityKo.containsIgnoreCase(keyword))
+                .or(house.districtKo.containsIgnoreCase(keyword))
+                .or(house.countryKo.containsIgnoreCase(keyword))
+                .or(house.addressEn.containsIgnoreCase(keyword))
+                .or(house.cityEn.containsIgnoreCase(keyword))
+                .or(house.districtEn.containsIgnoreCase(keyword))
+                .or(house.countryEn.containsIgnoreCase(keyword))
                 : null;
     }
 
     private BooleanExpression cityEq(String city) {
-        return hasText(city) ? house.city.eq(city) : null;
+        return hasText(city) ? house.cityKo.eq(city)
+                .or(house.cityEn.eq(city))
+                .or(house.countryKo.eq(city))
+                .or(house.countryEn.eq(city)) : null;
+    }
+
+    private BooleanExpression countryEq(String country) {
+        return hasText(country) ? house.countryKo.eq(country)
+                .or(house.countryEn.eq(country)) : null;
     }
 
     private BooleanExpression houseTypeEq(com.stayswap.house.constant.HouseType houseType) {
@@ -358,7 +382,7 @@ public class HouseRepositoryImpl implements HouseRepositoryCustom {
                         orderSpecifiers.add(new OrderSpecifier<>(direction, house.title));
                         break;
                     case "city":
-                        orderSpecifiers.add(new OrderSpecifier<>(direction, house.city));
+                        orderSpecifiers.add(new OrderSpecifier<>(direction, house.cityKo));
                         break;
                 }
             }


### PR DESCRIPTION
## 💡 **개요**
- #93 
## 📑 **작업 사항**
- 프론트에서 Geocoding api 활용해 한글 주소 입력시 자동으로 영문 주소도 함께 저장되게 dto 추가
