### PR TITLE
feat: 숙소 상세조회 응답에 좋아요 상태 필드 추가 및 userinfo false 추가

### DIFF
--- a/stayswap-api/src/main/java/com/stayswap/common/resolver/UserInfoArgumentResolver.java
+++ b/stayswap-api/src/main/java/com/stayswap/common/resolver/UserInfoArgumentResolver.java
@@ -4,9 +4,12 @@ import com.stayswap.jwt.service.TokenManager;
 import com.stayswap.common.resolver.userinfo.UserInfo;
 import com.stayswap.common.resolver.userinfo.UserInfoDto;
 import com.stayswap.jwt.constant.Role;
+import com.stayswap.error.exception.AuthenticationException;
+import com.stayswap.code.ErrorCode;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -15,6 +18,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserInfoArgumentResolver implements HandlerMethodArgumentResolver {
@@ -32,16 +36,39 @@ public class UserInfoArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String authorizationHeader = request.getHeader("Authorization");
-        String token = authorizationHeader.split(" ")[1];
+        
+        // UserInfo 어노테이션에서 required 값 확인
+        UserInfo userInfoAnnotation = parameter.getParameterAnnotation(UserInfo.class);
+        boolean required = userInfoAnnotation != null ? userInfoAnnotation.required() : true;
+        
+        // Authorization 헤더가 없거나 Bearer 토큰이 아닌 경우
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            if (required) {
+                throw new AuthenticationException(ErrorCode.NOT_EXISTS_AUTHORIZATION);
+            }
+            log.debug("Authorization header is missing, but required=false, returning null");
+            return null;
+        }
+        
+        try {
+            String token = authorizationHeader.split(" ")[1];
+            Claims tokenClaims = tokenManager.getTokenClaims(token);
+            Long userId = Long.valueOf((Integer) tokenClaims.get("userId"));
+            String role = (String) tokenClaims.get("role");
 
-        Claims tokenClaims = tokenManager.getTokenClaims(token);
-        Long userId = Long.valueOf((Integer) tokenClaims.get("userId"));
-        String role = (String) tokenClaims.get("role");
-
-        return UserInfoDto.builder()
-                .userId(userId)
-                .role(Role.from(role))
-                .build();
+            UserInfoDto userInfoDto = UserInfoDto.builder()
+                    .userId(userId)
+                    .role(Role.from(role))
+                    .build();
+            
+            return userInfoDto;
+        } catch (Exception e) {
+            if (required) {
+                log.error("Failed to resolve user info from token", e);
+                throw e;
+            }
+            log.debug("Failed to resolve user info from token, but required=false, returning null", e);
+            return null;
+        }
     }
-
 }

--- a/stayswap-api/src/main/java/com/stayswap/common/resolver/userinfo/UserInfo.java
+++ b/stayswap-api/src/main/java/com/stayswap/common/resolver/userinfo/UserInfo.java
@@ -11,4 +11,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(hidden = true)
 public @interface UserInfo {
+    boolean required() default true;
 }

--- a/stayswap-api/src/main/java/com/stayswap/house/controller/HouseController.java
+++ b/stayswap-api/src/main/java/com/stayswap/house/controller/HouseController.java
@@ -95,13 +95,16 @@ public class HouseController {
     @Operation(
             summary = "숙소 상세 조회 API",
             description = "숙소 상세 정보를 조회합니다. " +
-                    "숙소의 기본 정보, 이미지, 편의시설 정보, 호스트 ID 등을 포함합니다."
+                    "숙소의 기본 정보, 이미지, 편의시설 정보, 호스트 ID 등을 포함합니다. " +
+                    "로그인한 사용자의 경우 좋아요 상태도 함께 반환합니다."
     )
     @GetMapping("/{houseId}")
     public RestApiResponse<HouseDetailResponse> getHouseDetail(
-            @PathVariable("houseId") Long houseId) {
+            @PathVariable("houseId") Long houseId,
+            @UserInfo(required = false) UserInfoDto userInfo) {
         
-        return RestApiResponse.success(houseService.getHouseDetail(houseId));
+        Long userId = userInfo != null ? userInfo.getUserId() : null;
+        return RestApiResponse.success(houseService.getHouseDetail(houseId, userId));
     }
     
     @Operation(

--- a/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/HouseDetailResponse.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/model/dto/response/HouseDetailResponse.java
@@ -97,6 +97,14 @@ public class HouseDetailResponse {
     @Schema(description = "지도 영역 남서쪽 경도", example = "126.9775")
     private Double viewportSouthwestLng;
 
+    @Schema(description = "사용자가 좋아요 누른 숙소 여부", example = "true")
+    private Boolean isLiked;
+
+    // 좋아요 상태 설정 메서드
+    public void setIsLiked(Boolean isLiked) {
+        this.isLiked = isLiked;
+    }
+
     @Getter
     @Builder
     @NoArgsConstructor

--- a/stayswap-domain/src/main/java/com/stayswap/house/repository/HouseRepositoryImpl.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/repository/HouseRepositoryImpl.java
@@ -145,7 +145,8 @@ public class HouseRepositoryImpl implements HouseRepositoryCustom {
                         house.viewportNortheastLat,
                         house.viewportNortheastLng,
                         house.viewportSouthwestLat,
-                        house.viewportSouthwestLng
+                        house.viewportSouthwestLng,
+                        Expressions.constant(false) // isLiked
                 ))
                 .from(house)
                 .join(house.user, user)

--- a/stayswap-domain/src/main/java/com/stayswap/house/service/HouseService.java
+++ b/stayswap-domain/src/main/java/com/stayswap/house/service/HouseService.java
@@ -8,6 +8,7 @@ import com.stayswap.house.model.dto.request.UpdateHouseRequest;
 import com.stayswap.house.model.dto.response.*;
 import com.stayswap.house.model.entity.House;
 import com.stayswap.house.repository.HouseRepository;
+import com.stayswap.house.service.HouseLikeService;
 import com.stayswap.user.model.entity.User;
 import com.stayswap.user.repository.UserRepository;
 import jakarta.validation.Valid;
@@ -34,6 +35,7 @@ public class HouseService {
     private final HouseImgService houseImgService;
     private final UserRepository userRepository;
     private final HouseRedisService houseRedisService;
+    private final HouseLikeService houseLikeService;
 
     // 숙소 등록
     public CreateHouseResponse createHouse(Long userId,
@@ -98,13 +100,24 @@ public class HouseService {
 
     // 숙소 상세 정보 조회
     @Transactional(readOnly = true)
-    public HouseDetailResponse getHouseDetail(Long houseId) {
+    public HouseDetailResponse getHouseDetail(Long houseId, Long userId) {
+
         HouseDetailResponse houseDetail = houseRepository.getHouseDetail(houseId);
         
         if (houseDetail == null) {
             throw new NotFoundException(NOT_EXISTS_HOUSE);
         }
+
+        // 좋아요 상태 확인 (로그인한 사용자만)
+        boolean isLiked = false;
+        if (userId != null) {
+            isLiked = houseLikeService.isLiked(houseId, userId);
+        } else {
+        }
         
+        // 좋아요 상태 설정
+        houseDetail.setIsLiked(isLiked);
+
         return houseDetail;
     }
 


### PR DESCRIPTION
## 💡 **개요**
- 
## 📑 **작업 사항**
1. 숙소 상세조회 응답(HouseDetailResponse)에 isLiked 필드 추가
   - 로그인한 사용자가 해당 숙소에 좋아요를 눌렀는지 여부를 표시
   - 비로그인 사용자의 경우 기본값 false 반환

2. UserInfo 어노테이션 개선
   - required 속성 추가 (default: true)
   - 비로그인 상태에서도 API 호출 가능하도록 개선
   - UserInfoArgumentResolver에서 토큰 검증 실패 시 required=false인 경우 null 반환

